### PR TITLE
Add Fatal support and customisable writers

### DIFF
--- a/log.go
+++ b/log.go
@@ -2,39 +2,45 @@ package log
 
 import (
 	"fmt"
+	"io"
 	"os"
 )
 
-// Verbose enables debug.
-var Verbose = false
-
-// Width of column.
-var Width = "14"
+var (
+	// Verbose enables debug.
+	Verbose = false
+	// Width of column.
+	Width = "14"
+	// Writer defines the io.Writer for all non-error output (Debug, Info, Warn)
+	Writer io.Writer = os.Stdout
+	// ErrorWriter defines the io.Writer for error output (Error, Fatal)
+	ErrorWriter io.Writer = os.Stderr
+)
 
 // Info.
 func Info(key string, format string, args ...interface{}) {
 	p := fmt.Sprintf("\033[36m%"+Width+"s \033[90m:\033[0m ", key)
-	fmt.Printf(p+format+"\n", args...)
+	fmt.Fprintf(Writer, p+format+"\n", args...)
 }
 
 // Debug.
 func Debug(key string, format string, args ...interface{}) {
 	if Verbose {
 		p := fmt.Sprintf("\033[96m%"+Width+"s \033[90m:\033[0m ", key)
-		fmt.Printf(p+format+"\n", args...)
+		fmt.Fprintf(Writer, p+format+"\n", args...)
 	}
 }
 
 // Warning.
 func Warn(format string, args ...interface{}) {
 	p := fmt.Sprintf("\033[33m%"+Width+"s \033[90m:\033[0m ", "warn")
-	fmt.Printf(p+format+"\n", args...)
+	fmt.Fprintf(Writer, p+format+"\n", args...)
 }
 
 // Error.
 func Error(err error) {
 	p := fmt.Sprintf("\033[31m%"+Width+"s \033[90m:\033[0m ", "error")
-	fmt.Fprintf(os.Stderr, p+"%s\n", err.Error())
+	fmt.Fprintf(ErrorWriter, p+"%s\n", err.Error())
 }
 
 // Fatal.

--- a/log.go
+++ b/log.go
@@ -36,3 +36,9 @@ func Error(err error) {
 	p := fmt.Sprintf("\033[31m%"+Width+"s \033[90m:\033[0m ", "error")
 	fmt.Fprintf(os.Stderr, p+"%s\n", err.Error())
 }
+
+// Fatal.
+func Fatal(err error) {
+	Error(err)
+	os.Exit(1)
+}


### PR DESCRIPTION
* Support for `Fatal` log which is supported by other loggers to log an error and exit with exit code 1
* Add customisable `io.Writer` for standard log output and error log output e.g. to mock out/capture logging in unit tests